### PR TITLE
Dev/testsurmisemove

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "software/surmise"]
 	path = software/surmise
-	url = https://github.com/surmising/surmise
+	url = https://github.com/bandframework/surmise
 [submodule "software/QGP_Bayes"]
 	path = software/QGP_Bayes
 	url = https://github.com/danOSU/QGP_Bayes.git

--- a/resources/sdkpolicies/README.md
+++ b/resources/sdkpolicies/README.md
@@ -14,4 +14,4 @@ Examples of completed SDK policy compatibility documents include:
 -  [parmoo-bandsdk.md](/software/parmoo/parmoo-bandsdk.md)
 -  [QGP_Bayesbandsdk.md](https://github.com/danOSU/QGP_Bayes/blob/main/QGP_Bayesbandsdk.md)
 -  [SAMBAbandsdk.md](https://github.com/asemposki/SAMBA/blob/main/SAMBAbandsdk.md)
--  [surmisebandsdk.md](https://github.com/surmising/surmise/blob/main/surmisebandsdk.md)
+-  [surmisebandsdk.md](https://github.com/bandframework/surmise/blob/main/surmisebandsdk.md)


### PR DESCRIPTION
This is a test of what changes are needed for an org change of surmise.

Note that the changes are going to the develop branch of bandframework, which could be OK because a release is imminent ... really this should be a hotfix to the main branch because the surmise submodule is probably broken after an org change