### PR TITLE
Pull request to update surmise submodule in bandframework

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ BAND Framework tools and examples are found in [software/](/software/).
 
 As of version 0.2.0+dev, the following tools are included:
 
-- surmise: A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
+- surmise (v0.2.1): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
 - SaMBA: The Sandbox for Mixing via Bayesian Analysis.
 - parMOO: A Python library for parallel multiobjective simulation optimization.
 - Taweret: A Python package containing multiple Bayesian Model Mixing methods.


### PR DESCRIPTION
surmise v0.2.1 is the current release to be included under bandframework software.

Guide for reviewers:
1. (Colab environment) Run the [colab notebook](https://colab.research.google.com/drive/1f4gKTCLEAGE8r-aMWOoGvY-O6zNqg1qj?usp=drive_link).
2. (Local) Follow installation and testing sections under https://surmise.readthedocs.io/en/latest/introduction.html#installation.
