### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
         branch = main
 [submodule "software/SAMBA"]
 	path = software/SAMBA
-	url = https://www.github.com/asemposki/SAMBA
+	url = https://www.github.com/asemposki/SAMBA.git
 [submodule "software/Taweret"]
 	path = software/Taweret
 	url = https://github.com/bandframework/Taweret

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
         branch = main
 [submodule "software/SAMBA"]
 	path = software/SAMBA
-	url = https://www.github.com/asemposki/SAMBA.git
+	url = https://github.com/asemposki/SAMBA.git
 [submodule "software/Taweret"]
 	path = software/Taweret
 	url = https://github.com/bandframework/Taweret


### PR DESCRIPTION
Attempts to fix the warning

`
warning: redirecting to https://github.com/asemposki/SAMBA.git/ `

that I receive when doing a fresh recursive clone.