### PR TITLE
113 ensure sdk list is updated prior to release v04

### DIFF
--- a/resources/dev_guide/release-proc.rst
+++ b/resources/dev_guide/release-proc.rst
@@ -24,6 +24,8 @@ Before release
 
 - Check `bandsdk.md </resources/sdkpolicies/bandsdk.md>`_ *Citing bandframework* for correctness.
 
+- Check `sdkpolicies README </resources/sdkpolicies/README.md>`_ for correctness (e.g., ensure that each software in the release has a working link for its SDK compliance).
+
 - Tests are run with source to be released (this may iterate):
 
   - Online CI (GitHub Actions) tests must pass.

--- a/resources/dev_guide/release-proc.rst
+++ b/resources/dev_guide/release-proc.rst
@@ -5,6 +5,8 @@ A release can be undertaken only by a project administrator.
 A project administrator should have an administrator role on the `bandframework
 GitHub <https://github.com/bandframework>`_.
 
+Best practice is to follow the version of this process as recorded on the ``develop`` and/or release branch(es). 
+
 Before release
 --------------
 

--- a/resources/dev_guide/release-proc.rst
+++ b/resources/dev_guide/release-proc.rst
@@ -48,7 +48,7 @@ An administrator will take the following steps.
 
 - Once CI tests have passed on ``main``:
 
-  - A GitHub release will be taken from the ``main``
+  - A GitHub release will be taken from the ``main``.
 
 - If the merge was made from a release branch (instead of ``develop``), merge this
   branch into ``develop``.


### PR DESCRIPTION
@mosesyhc This is meant to address #113 .

That said, we need to either keep the issue open or remember to follow the release process on develop (not main), which is probably best practice anyway.