### PR TITLE
Update ROSE to v1.1.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ New capabilities and notable changes:
 
 - added BAND-compatible PUQ, a parallel package for generating experimental designs tailored for uncertainty quantification at `v0.1.0 <https://github.com/parallelUQ/PUQ/releases/tag/v0.1.0>`_
 - updated BAND-compatible parMOO to `v0.4.1 <https://github.com/parmoo/parmoo/releases/tag/v0.4.1>`_, which now includes JIT compilation and automatic differentiation capabilities via `jax`
+- updated BAND-compatible rose, a reduced-order scattering emulator at `v1.1.3 <https://github.com/bandframework/rose/releases/tag/v1.1.3>`_
 - updated BAND-compatible SaMBA to `v1.1.0 <https://github.com/asemposki/SAMBA/releases/tag/v1.1.0>`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ New capabilities and notable changes:
 
 - added BAND-compatible PUQ, a parallel package for generating experimental designs tailored for uncertainty quantification at `v0.1.0 <https://github.com/parallelUQ/PUQ/releases/tag/v0.1.0>`_
 - updated BAND-compatible parMOO to `v0.4.1 <https://github.com/parmoo/parmoo/releases/tag/v0.4.1>`_, which now includes JIT compilation and automatic differentiation capabilities via `jax`
-- updated BAND-compatible rose to `v1.1.3 <https://github.com/bandframework/rose/releases/tag/v1.1.3>`_
+- updated BAND-compatible rose to `v1.1.3 <https://github.com/bandframework/rose/releases/tag/v1.1.3>`_, includes new features on the backend for performance and greatly expands our test coverage
 - updated BAND-compatible SaMBA to `v1.1.0 <https://github.com/asemposki/SAMBA/releases/tag/v1.1.0>`_
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ New capabilities and notable changes:
 
 - added BAND-compatible PUQ, a parallel package for generating experimental designs tailored for uncertainty quantification at `v0.1.0 <https://github.com/parallelUQ/PUQ/releases/tag/v0.1.0>`_
 - updated BAND-compatible parMOO to `v0.4.1 <https://github.com/parmoo/parmoo/releases/tag/v0.4.1>`_, which now includes JIT compilation and automatic differentiation capabilities via `jax`
-- updated BAND-compatible rose, a reduced-order scattering emulator at `v1.1.3 <https://github.com/bandframework/rose/releases/tag/v1.1.3>`_
+- updated BAND-compatible rose to `v1.1.3 <https://github.com/bandframework/rose/releases/tag/v1.1.3>`_
 - updated BAND-compatible SaMBA to `v1.1.0 <https://github.com/asemposki/SAMBA/releases/tag/v1.1.0>`_
 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ As of version 0.3.0+dev, the following tools are included:
 - surmise ([v0.2.1](https://github.com/bandframework/surmise/releases/tag/v0.2.1 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
 - SaMBA ([v1.1.0](https://github.com/asemposki/SAMBA/releases/tag/v1.1.0 )): The Sandbox for Mixing via Bayesian Analysis.
 - parMOO ([v0.4.1](https://github.com/parmoo/parmoo/releases/tag/v0.4.1 )): A Python library for parallel multiobjective simulation optimization.
-- rose ([v1.0.0](https://github.com/bandframework/rose/releases/tag/v1.0.0 )): A reduced-order scattering emulator.
+- rose ([v1.1.3](https://github.com/bandframework/rose/releases/tag/v1.1.3 )): A reduced-order scattering emulator.
 - BMEX ([v0.1.1](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.1 )): A web application for exploring quantified theoretical model predictions of nuclear masses and related quantities.
 - Taweret ([v1.0.0](https://github.com/bandframework/Taweret/releases/tag/v1.0.0 )): A Python package containing multiple Bayesian Model Mixing methods.
 - PUQ ([v0.1.0](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.0 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.


### PR DESCRIPTION
This represents the changes ROSE has seen over the last year of development. Full changelogs and info are listed in the release page. We have a few active actions that build the package, docs, as well as some analytics collectors. Tests can be ran manually, though they are also triggered by the github actions, so you can check the run history for a log.