### PR TITLE
Post V0.4.0 release: bringing develop up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ BAND Framework elements are of two main types:
 
 BAND Framework tools and examples are found in [software/](/software/).
 
-As of version 0.3.0+dev, the following tools are included:
+As of version 0.4.0+dev, the following tools are included:
 
 - surmise ([v0.3.0](https://github.com/bandframework/surmise/releases/tag/v0.3.0 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
 - SaMBA ([v1.1.0](https://github.com/asemposki/SAMBA/releases/tag/v1.1.0 )): The Sandbox for Mixing via Bayesian Analysis.
@@ -47,7 +47,7 @@ As of version 0.3.0+dev, the following tools are included:
 - PUQ ([v0.1.0](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.0 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - [SmoothEmulator](/software/SmoothEmulator): A simplex sampler, emulator trainer, and MCMC explorer that employs a smooth emulator.
 
-The following examples are part of version 0.3.0+dev:
+The following examples are part of version 0.4.0+dev:
 
 - [Bfrescox](/software/Bfrescox): A BAND extension of the frescox scattering code for coupled-channels calculations that uses surmise.
 - [BRICK](/software/BRICK): The Bayesian R-matrix Inference Code Kit, facilitates extraction of R-matrix parameters from experimental data.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ BAND Framework elements are of two main types:
 
 BAND Framework tools and examples are found in [software/](/software/).
 
-As of version 0.4.0, the following tools are included:
+As of version 0.4.0+dev, the following tools are included:
 
 - surmise ([v0.3.0](https://github.com/bandframework/surmise/releases/tag/v0.3.0 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
 - SaMBA ([v1.1.0](https://github.com/asemposki/SAMBA/releases/tag/v1.1.0 )): The Sandbox for Mixing via Bayesian Analysis.
@@ -47,7 +47,7 @@ As of version 0.4.0, the following tools are included:
 - PUQ ([v0.1.0](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.0 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - [SmoothEmulator](/software/SmoothEmulator): A simplex sampler, emulator trainer, and MCMC explorer that employs a smooth emulator.
 
-The following examples are part of version 0.4.0:
+The following examples are part of version 0.4.0+dev:
 
 - [Bfrescox](/software/Bfrescox): A BAND extension of the frescox scattering code for coupled-channels calculations that uses surmise.
 - [BRICK](/software/BRICK): The Bayesian R-matrix Inference Code Kit, facilitates extraction of R-matrix parameters from experimental data.
@@ -107,7 +107,7 @@ Please use the following to cite the BAND Framework:
         Scott Pratt and Oleh Savchuk and Alexandra C. Semposki and \"Ozge S\"urer and 
         Stefan M. Wild and John C. Yannotty},
         institution = {},
-        number      = {Version 0.4.0},
+        number      = {Version 0.4.0+dev},
         year        = {2024},
         url         = {https://github.com/bandframework/bandframework}
     }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ BAND Framework elements are of two main types:
 
 BAND Framework tools and examples are found in [software/](/software/).
 
-As of version 0.4.0+dev, the following tools are included:
+As of version 0.4.0, the following tools are included:
 
 - surmise ([v0.3.0](https://github.com/bandframework/surmise/releases/tag/v0.3.0 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
 - SaMBA ([v1.1.0](https://github.com/asemposki/SAMBA/releases/tag/v1.1.0 )): The Sandbox for Mixing via Bayesian Analysis.
@@ -47,7 +47,7 @@ As of version 0.4.0+dev, the following tools are included:
 - PUQ ([v0.1.0](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.0 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - [SmoothEmulator](/software/SmoothEmulator): A simplex sampler, emulator trainer, and MCMC explorer that employs a smooth emulator.
 
-The following examples are part of version 0.4.0+dev:
+The following examples are part of version 0.4.0:
 
 - [Bfrescox](/software/Bfrescox): A BAND extension of the frescox scattering code for coupled-channels calculations that uses surmise.
 - [BRICK](/software/BRICK): The Bayesian R-matrix Inference Code Kit, facilitates extraction of R-matrix parameters from experimental data.
@@ -107,7 +107,7 @@ Please use the following to cite the BAND Framework:
         Scott Pratt and Oleh Savchuk and Alexandra C. Semposki and \"Ozge S\"urer and 
         Stefan M. Wild and John C. Yannotty},
         institution = {},
-        number      = {Version 0.4.0+dev},
+        number      = {Version 0.4.0},
         year        = {2024},
         url         = {https://github.com/bandframework/bandframework}
     }


### PR DESCRIPTION
This will be the PR post v0.4.0 release that brings develop up to date; see #131.
 If there are additional changes to `develop`, these should be pulled into this branch before this branch is merged into `develop`.