### PR TITLE
Update release-proc.rst

### DIFF
--- a/resources/dev_guide/release-proc.rst
+++ b/resources/dev_guide/release-proc.rst
@@ -20,7 +20,7 @@ Before release
 - Ensure that links and references have been updated (e.g., no occurrences of ``privateband``).
 
 - Version number is updated wherever it appears and ``+dev`` suffix is removed
-  (in `README.md </README.md>`_ and possibly in `CHANGELOG.rst </CHANGELOG.rst>`_).
+  (in `README.md </README.md>`_, `AUTHORS </AUTHORS>`_, `bandsdk.md </resources/sdkpolicies/bandsdk.md>`_, and possibly in `CHANGELOG.rst </CHANGELOG.rst>`_).
 
 - Check `README.md </README.md>`_ *Citing bandframework* for correctness (e.g., ensure that author list matches `AUTHORS </AUTHORS>`_).
 


### PR DESCRIPTION
In releasing v0.4.0, I found two more places where the `+dev` needed to be appended