### PR TITLE
Initial add of LCGP as submodule

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -38,6 +38,7 @@ jitrbandsdk
 JOSS
 Jupyter
 Kataria
+lcgp
 LHS
 LLNL
 Loeppky

--- a/.github/workflows/bandframework-ci.yml
+++ b/.github/workflows/bandframework-ci.yml
@@ -31,4 +31,4 @@ jobs:
         uses: paramt/url-checker@master
         with:
           files: "README.md,software/README.md,resources/README.md,resources/sdkpolicies/README.md,resources/sdkpolicies/bandsdk.md,resources/sdkpolicies/template.md,resources/dev_guide/git_instructions_for_submodules.md"
-          blacklist: https://doi.org/10.1088/1361-6471/abf1df,BMEX-bandsdk.md,Taweretbandsdk.md,SAMBAbandsdk.md,brickbandsdk.md,surmisebandsdk.md,frescoxbandsdk.md,template.md,bandsdk.md,parmoo-bandsdk.md,foobandsdk.md,PUQ-bandsdk.md,nsat-bandsdk.md,SmoothEmulatorSDK.md,jitrbandsdk.md
+          blacklist: https://doi.org/10.1088/1361-6471/abf1df,BMEX-bandsdk.md,Taweretbandsdk.md,SAMBAbandsdk.md,brickbandsdk.md,surmisebandsdk.md,frescoxbandsdk.md,template.md,bandsdk.md,parmoo-bandsdk.md,foobandsdk.md,PUQ-bandsdk.md,nsat-bandsdk.md,SmoothEmulatorSDK.md,jitrbandsdk.md,lcgp-bandsdk.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "software/nuclear_saturation"]
 	path = software/nuclear_saturation
 	url = git@github.com:cdrischler/nuclear_saturation.git
+[submodule "software/LCGP"]
+	path = software/LCGP
+	url = git@github.com:mosesyhc/LCGP.git

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ As of version 0.4.0+dev, the following tools are included:
 - rose ([v1.1.3](https://github.com/bandframework/rose/releases/tag/v1.1.3 )): A reduced-order scattering emulator.
 - Taweret ([v1.1.0](https://github.com/bandframework/Taweret/releases/tag/v1.1.0 )): A Python package containing multiple Bayesian Model Mixing methods.
 - PUQ ([v0.1.0](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.0 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
+- lcgp ([v0.2.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs. 
 
 The following examples are part of version 0.4.0+dev:
 
@@ -70,6 +71,7 @@ BAND Framework currently includes some dependencies via git submodules. Currentl
 * [software/](software/)surmise
 * [software/](software/)Taweret
 * [software/](software/)jitr
+* [software/](software/)lcgp
 
 As a consequence, when cloning the BAND Framework repository, the submodules can be retrieved automatically via
 - `git clone --recursive` (in place of the usual `git clone`)

--- a/resources/sdkpolicies/README.md
+++ b/resources/sdkpolicies/README.md
@@ -13,7 +13,7 @@ Examples of completed SDK policy compatibility documents include:
 -  [brickbandsdk.md](/software/BRICK/brickbandsdk.md)
 -  [frescoxbandsdk.md](/software/Bfrescox/frescoxbandsdk.md)
 -  [jitrbandsdk.md](https://github.com/beykyle/jitr/blob/main/jitrbandsdk.md)
--  [lcgp-bandsdk.md](https://github.com/mosesyhc/LCGP/blob/v0.2.1/lcgp-bandsdk.md)
+-  [lcgp-bandsdk.md](https://github.com/mosesyhc/LCGP/blob/main/lcgp-bandsdk.md)
 -  [nsat-bandsdk.md](https://github.com/cdrischler/nuclear_saturation/blob/main/nsat-bandsdk.md)
 -  [parmoo-bandsdk.md](/software/parmoo/parmoo-bandsdk.md)
 -  [PUQ-bandsdk.md](/software/PUQ/PUQ-bandsdk.md)

--- a/resources/sdkpolicies/README.md
+++ b/resources/sdkpolicies/README.md
@@ -13,6 +13,7 @@ Examples of completed SDK policy compatibility documents include:
 -  [brickbandsdk.md](/software/BRICK/brickbandsdk.md)
 -  [frescoxbandsdk.md](/software/Bfrescox/frescoxbandsdk.md)
 -  [jitrbandsdk.md](https://github.com/beykyle/jitr/blob/main/jitrbandsdk.md)
+-  [lcgp-bandsdk.md](https://github.com/mosesyhc/LCGP/blob/v0.2.1/lcgp-bandsdk.md)
 -  [nsat-bandsdk.md](https://github.com/cdrischler/nuclear_saturation/blob/main/nsat-bandsdk.md)
 -  [parmoo-bandsdk.md](/software/parmoo/parmoo-bandsdk.md)
 -  [PUQ-bandsdk.md](/software/PUQ/PUQ-bandsdk.md)


### PR DESCRIPTION
This PR adds the LCGP package as a submodule.

For Moses:
- [x] Update BAND SDK

For reviewers:
- [x] Please install and test the package using instructions in [LCGP installation](https://lcgp.readthedocs.io/en/latest/#installation).  
- [x] Verify that `lcgp.__version__` returns `v0.2.0`.
- [x] _Optional test_. In addition, you may run the example script to test the package usage, shown below:

```
pip install matplotlib pandas
python ./illustration-examples/lcgp-3d.py
```
  
  This script should return a subdirectory `results_figures` with two plots, and a console output of error measures.  An example plot is shown here:
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/b3f2c2f6-967d-463b-bf92-cb895429877f" />


**Note:** There are known runtime warnings in using tensorflow.
