### PR TITLE
Adding submodule neutron-rich-bmm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 	path = examples/nuclear_saturation
 	url = https://github.com/cdrischler/nuclear_saturation
 
+[submodule "software/neutron-rich-bmm"]
+	path = software/neutron-rich-bmm
+	url = https://github.com/asemposki/neutron-rich-bmm


### PR DESCRIPTION
Adding the submodule neutron-rich-bmm which contains a use case of BMM for the neutron star EOS. 

Things I still need to do before this PR is merged:
- [x] Add SDK rules
- [ ] Clean up repo
- [ ] Check that the procedure in the README works
- [ ] (Optional, might need to be later on) Add a documentation website for readability (at least API)