### PR TITLE
Add pybmc as Software

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -3,6 +3,7 @@ Autoconf
 BAND's
 BANDCamp
 BANDsoftware
+BMC
 BMEX
 BRICK's
 Bayesbandsdk
@@ -29,17 +30,16 @@ Frederi
 Frescox
 Furnstahl
 GPL
+GPLv
 GPy
 GSL
 Gitflow
 Gramacy
 JETSCAPE
 JIT
-jitrbandsdk
 JOSS
 Jupyter
 Kataria
-lcgp
 LHS
 LLNL
 Loeppky
@@ -86,6 +86,7 @@ X-SCAPE
 aMWOoGvY
 al
 anl
+ascsn
 attr
 autofunction
 automodule
@@ -140,12 +141,14 @@ ipynb
 isotonic
 jgehrcke
 jitr
+jitrbandsdk
 JIT
 JOSS
 Jupyter
 Kataria
 kyle
 lbl
+lcgp
 libEnsemble
 ln
 macOS
@@ -154,6 +157,7 @@ mcs
 md
 miamioh
 mlbayeswoodbury
+mkdocs
 mosesyhc
 mplumlee
 msu
@@ -165,6 +169,7 @@ numpy
 nunes
 odell
 ohio
+orthogonalization
 ozgesurer
 parMOO
 parallelUQ
@@ -176,6 +181,8 @@ pre
 preprint
 privateband
 py
+pybmc
+pybmc's
 pypi
 pytest
 qj

--- a/.github/workflows/bandframework-ci.yml
+++ b/.github/workflows/bandframework-ci.yml
@@ -31,4 +31,4 @@ jobs:
         uses: paramt/url-checker@master
         with:
           files: "README.md,software/README.md,resources/README.md,resources/sdkpolicies/README.md,resources/sdkpolicies/bandsdk.md,resources/sdkpolicies/template.md,resources/dev_guide/git_instructions_for_submodules.md"
-          blacklist: https://doi.org/10.1088/1361-6471/abf1df,BMEX-bandsdk.md,Taweretbandsdk.md,SAMBAbandsdk.md,brickbandsdk.md,surmisebandsdk.md,frescoxbandsdk.md,template.md,bandsdk.md,parmoo-bandsdk.md,foobandsdk.md,PUQ-bandsdk.md,nsat-bandsdk.md,SmoothEmulatorSDK.md,jitrbandsdk.md,lcgp-bandsdk.md
+          blacklist: https://doi.org/10.1088/1361-6471/abf1df,BMEX-bandsdk.md,Taweretbandsdk.md,SAMBAbandsdk.md,brickbandsdk.md,surmisebandsdk.md,frescoxbandsdk.md,template.md,bandsdk.md,parmoo-bandsdk.md,foobandsdk.md,PUQ-bandsdk.md,nsat-bandsdk.md,SmoothEmulatorSDK.md,jitrbandsdk.md,lcgp-bandsdk.md,pybmc-bandsdk.md

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,12 +3,14 @@ Kyle Beyer
 Landon Buskirk
 Moses Y-H. Chan
 Tyler H. Chang
+Troy Dasher
 Richard James DeBoer
 Christian Drischler
 Richard J. Furnstahl
 Pablo Giuliani
 Kyle Godbey
 Kevin Ingles
+An Le
 Dananjaya Liyanage
 Filomena M. Nunes
 Daniel Odell

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,14 +3,12 @@ Kyle Beyer
 Landon Buskirk
 Moses Y-H. Chan
 Tyler H. Chang
-Troy Dasher
 Richard James DeBoer
 Christian Drischler
 Richard J. Furnstahl
 Pablo Giuliani
 Kyle Godbey
 Kevin Ingles
-An Le
 Dananjaya Liyanage
 Filomena M. Nunes
 Daniel Odell

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ New organization:
 New capabilities and notable changes:
 
 - Added BAND-compatible lcgp at `v0.2.1 <https://github.com/mosesyhc/LCGP/releases/tag/v0.2.1>`_, a tool for latent component Gaussian process emulation for multivariate stochastic simulations.
-- Added BAND-compatible pybmc at `v0.2.1 <https://github.com/ascsn/pybmc/releases/tag/v0.2.3>`_, a tool for performing Bayesian model combination on various predictive models.
+- Added BAND-compatible pybmc at `v0.2.4 <https://github.com/ascsn/pybmc/releases/tag/v0.2.4>`_, a tool for performing Bayesian model combination on various predictive models.
 - Updated BAND-compatible jitr to `v2.5.1 <https://github.com/beykyle/jitr/releases/tag/v2.5.1>`_, which fixes bugs in calculating some observables; also adds mass tables, a Reaction class, many examples, and other functionality. 
 - Updated BAND-compatible rose to `v1.1.7 <https://github.com/bandframework/rose/releases/tag/v1.1.7>`_, which includes minor bug fixes.
 - Updated BAND-compatible SAMBA to `v1.2.0 <https://github.com/asemposki/SAMBA/releases/tag/v1.2.0>`_, which fixes some GP mixing bugs. 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ New organization:
 New capabilities and notable changes:
 
 - Added BAND-compatible lcgp at `v0.2.1 <https://github.com/mosesyhc/LCGP/releases/tag/v0.2.1>`_, a tool for latent component Gaussian process emulation for multivariate stochastic simulations.
+- Added BAND-compatible pybmc at `v0.2.1 <https://github.com/ascsn/pybmc/releases/tag/v0.2.3>`_, a tool for performing Bayesian model combination on various predictive models.
 - Updated BAND-compatible jitr to `v2.5.1 <https://github.com/beykyle/jitr/releases/tag/v2.5.1>`_, which fixes bugs in calculating some observables; also adds mass tables, a Reaction class, many examples, and other functionality. 
 - Updated BAND-compatible rose to `v1.1.7 <https://github.com/bandframework/rose/releases/tag/v1.1.7>`_, which includes minor bug fixes.
 - Updated BAND-compatible SAMBA to `v1.2.0 <https://github.com/asemposki/SAMBA/releases/tag/v1.2.0>`_, which fixes some GP mixing bugs. 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ As of version 0.4.0+dev, the following tools are included:
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
 - lcgp ([v0.2.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
-- pybmc ([v0.2.1](https://github.com/ascsn/pybmc/releases/tag/v0.2.3 )): A Python package for performing Bayesian model combination on various predictive models.
+- pybmc ([v0.2.3](https://github.com/ascsn/pybmc/releases/tag/v0.2.3 )): A Python package for performing Bayesian model combination on various predictive models.
 
 [BANDsoftware_uses/](/BANDsoftware_uses/) contains uses of one or more BAND software tools:
 - [Bfrescox](/BANDsoftware_uses/Bfrescox): A BAND extension of the frescox scattering code for coupled-channels calculations that uses surmise.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ As of version 0.4.0+dev, the following tools are included:
 - Taweret ([v1.1.0](https://github.com/bandframework/Taweret/releases/tag/v1.1.0 )): A Python package containing multiple Bayesian Model Mixing methods.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
-- lcgp ([v0.2.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs. 
+- lcgp ([v0.2.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
+- pybmc ([v0.2.1](https://github.com/ascsn/pybmc/releases/tag/v0.2.3 )): A Python package for performing Bayesian model combination on various predictive models.
 
 [BANDsoftware_uses/](/BANDsoftware_uses/) contains uses of one or more BAND software tools:
 - [Bfrescox](/BANDsoftware_uses/Bfrescox): A BAND extension of the frescox scattering code for coupled-channels calculations that uses surmise.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ As of version 0.4.0+dev, the following tools are included:
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
 - lcgp ([v0.2.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
-- pybmc ([v0.2.3](https://github.com/ascsn/pybmc/releases/tag/v0.2.3 )): A Python package for performing Bayesian model combination on various predictive models.
+- pybmc ([v0.2.4](https://github.com/ascsn/pybmc/releases/tag/v0.2.4 )): A Python package for performing Bayesian model combination on various predictive models.
 
 [BANDsoftware_uses/](/BANDsoftware_uses/) contains uses of one or more BAND software tools:
 - [Bfrescox](/BANDsoftware_uses/Bfrescox): A BAND extension of the frescox scattering code for coupled-channels calculations that uses surmise.

--- a/resources/sdkpolicies/README.md
+++ b/resources/sdkpolicies/README.md
@@ -17,6 +17,7 @@ Examples of completed SDK policy compatibility documents include:
 -  [nsat-bandsdk.md](https://github.com/cdrischler/nuclear_saturation/blob/main/nsat-bandsdk.md)
 -  [parmoo-bandsdk.md](/software/parmoo/parmoo-bandsdk.md)
 -  [PUQ-bandsdk.md](/software/PUQ/PUQ-bandsdk.md)
+-  [pybmc-bandsdk.md](/software/pybmc/pybmc-bandsdk.md)
 -  [QGP_Bayesbandsdk.md](https://github.com/danOSU/QGP_Bayes/blob/main/QGP_Bayesbandsdk.md)
 -  [SAMBAbandsdk.md](https://github.com/asemposki/SAMBA/blob/main/SAMBAbandsdk.md)
 -  [SmoothEmulatorSDK.md](/software/SmoothEmulator/SmoothEmulatorSDK.md)

--- a/software/README.md
+++ b/software/README.md
@@ -13,5 +13,6 @@ As of v0.4.0+dev the following packages are present in this directory.
 - Taweret ([v1.1.0](https://github.com/bandframework/Taweret/releases/tag/v1.1.0 )): A Python package containing multiple Bayesian Model Mixing methods.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
+- pybmc ([v0.2.3](https://github.com/ascsn/pybmc/releases/tag/v0.2.3 )): A Python package for performing Bayesian model combination on various predictive models.
 
 Applications of these tools to nuclear-physics problems are provided in the ["BAND software uses"](/BANDsoftware_uses) directory. 

--- a/software/README.md
+++ b/software/README.md
@@ -13,6 +13,6 @@ As of v0.4.0+dev the following packages are present in this directory.
 - Taweret ([v1.1.0](https://github.com/bandframework/Taweret/releases/tag/v1.1.0 )): A Python package containing multiple Bayesian Model Mixing methods.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
-- pybmc ([v0.2.3](https://github.com/ascsn/pybmc/releases/tag/v0.2.3 )): A Python package for performing Bayesian model combination on various predictive models.
+- pybmc ([v0.2.4](https://github.com/ascsn/pybmc/releases/tag/v0.2.4 )): A Python package for performing Bayesian model combination on various predictive models.
 
 Applications of these tools to nuclear-physics problems are provided in the ["BAND software uses"](/BANDsoftware_uses) directory. 

--- a/software/pybmc/README.md
+++ b/software/pybmc/README.md
@@ -1,0 +1,34 @@
+# pybmc in BAND 
+
+pybmc is a Python package for performing Bayesian Model Combination (BMC) on various predictive models. It provides tools for data handling, orthogonalization, Gibbs sampling, and prediction with uncertainty quantification.
+
+A [BAND SDK v0.2 Community Policy](/resources/sdkpolicies/bandsdk.md) compatibility documentation for pybmc is contained in [pybmc-bandsdk.md](/software/pybmc/pybmc-bandsdk.md).
+
+The version of pybmc adopted for the BAND Framework is v0.2.3, found [here](https://github.com/ascsn/pybmc/tree/v0.2.3).
+
+## pybmc Installation
+
+Complete installation and testing details for pybmc are available at the [pybmc repo](https://github.com/ascsn/pybmc). pybmc documentation is available [here](https://ascsn.github.io/pybmc/).
+
+The easiest way to get a minimal installation of pybmc is via the Python package index, PyPI (commonly called pip):
+
+```
+pip install < --user > pybmc
+```
+where the braces around `< --user >` indicate that the `--user` flag is optional.
+
+
+You can also clone pybmc from our GitHub and ``pip`` install it
+in-place, so that you can easily pull the latest version or checkout
+the ``develop`` branch for pre-release features.
+On Debian-based systems with a bash shell, this looks like:
+
+```
+git clone https://github.com/ascsn/pybmc
+cd pybmc
+pip install -e .
+```
+
+## pybmc Examples
+
+For a simple example of the package in action, check the Usage section of the documentation [here](https://ascsn.github.io/pybmc/usage/#1-load-and-prepare-data). For an interactive notebook of the same procedure, you can load [this file](https://github.com/ascsn/pybmc/blob/v0.2.3/pybmc/test.ipynb) locally or in any Jupyter environment.

--- a/software/pybmc/README.md
+++ b/software/pybmc/README.md
@@ -4,7 +4,7 @@ pybmc is a Python package for performing Bayesian Model Combination (BMC) on var
 
 A [BAND SDK v0.2 Community Policy](/resources/sdkpolicies/bandsdk.md) compatibility documentation for pybmc is contained in [pybmc-bandsdk.md](/software/pybmc/pybmc-bandsdk.md).
 
-The version of pybmc adopted for the BAND Framework is v0.2.3, found [here](https://github.com/ascsn/pybmc/tree/v0.2.3).
+The version of pybmc adopted for the BAND Framework is v0.2.4, found [here](https://github.com/ascsn/pybmc/tree/v0.2.4).
 
 ## pybmc Installation
 
@@ -31,4 +31,4 @@ pip install -e .
 
 ## pybmc Examples
 
-For a simple example of the package in action, check the Usage section of the documentation [here](https://ascsn.github.io/pybmc/usage/#1-load-and-prepare-data). For an interactive notebook of the same procedure, you can load [this file](https://github.com/ascsn/pybmc/blob/v0.2.3/pybmc/test.ipynb) locally or in any Jupyter environment.
+For a simple example of the package in action, check the Usage section of the documentation [here](https://ascsn.github.io/pybmc/usage/#1-load-and-prepare-data). For an interactive notebook of the same procedure, you can load [this file](https://github.com/ascsn/pybmc/blob/v0.2.4/pybmc/test.ipynb) locally or in any Jupyter environment.

--- a/software/pybmc/pybmc-bandsdk.md
+++ b/software/pybmc/pybmc-bandsdk.md
@@ -1,0 +1,52 @@
+# BAND SDK v0.2 Community Policy Compatibility for pybmc
+
+
+> This document summarizes the efforts of current and future BAND member packages to achieve compatibility with the BAND SDK community policies.  Additional details on the BAND SDK are available [here](/resources/sdkpolicies/bandsdk.md) and should be considered when filling out this form. The most recent copy of this template exists [here](/resources/sdkpolicies/template.md).
+>
+> This file should filled out and placed in the directory in the `bandframework` repository representing the software name appended by `bandsdk`.  For example, if you have a software `foo`, the compatibility file should be named `foobandsdk.md` and placed in the directory housing the software in the `bandframework` repository. No open source code can be included without this file.
+>
+> All code included in this repository will be open source.  If a piece of code does not contain a open-source LICENSE file as mentioned in the requirements below, then it will be automatically licensed as described in the LICENSE file in the root directory of the bandframework repository.
+>
+> Please provide information on your compatibility status for each mandatory policy and, if possible, also for recommended policies. If you are not compatible, state what is lacking and what are your plans on how to achieve compliance. For current BAND SDK packages: If you were not fully compatible at some point, please describe the steps you undertook to fulfill the policy. This information will be helpful for future BAND member packages.
+>
+> To suggest changes to these requirements or obtain more information, please contact [BAND](https://bandframework.github.io/team).
+>
+> Details on citing the current version of the BAND Framework can be found in the [README](https://github.com/bandframework/bandframework).
+
+**Website:** https://ascsn.github.io/pybmc/ \
+**Contact:** pybmc@ascsn.net \
+**Description:** pybmc is a Python package for performing Bayesian Model Combination (BMC) on various predictive models. It provides tools for data handling, orthogonalization, Gibbs sampling, and prediction with uncertainty quantification.
+
+
+### Mandatory Policies
+
+**BAND SDK**
+| # | Policy                 |Support| Notes                   |
+|---|-----------------------|-------|-------------------------|
+| 1. | Support BAND community GNU Autoconf, CMake, or other build options. |Full| pybmc is a Python package and uses Poetry for dependency and build system management. GNU Autoconf or CMake are unsuitable for a Python package. |
+| 2. | Have a README file in the top directory that states a specific set of testing procedures for a user to verify the software was installed and run correctly. | Full| In addition to a README, pybmc's installation can be tested via pytest by running ``poetry run pytest``.|
+| 3. | Provide a documented, reliable way to contact the development team. |Full| The pybmc team can be contacted through the public [issues page on GitHub](https://github.com/ascsn/pybmc) or via an e-mail to [pybmc@ascsn.net](pybmc@ascsn.net).|
+| 4. | Come with an open-source license |Full| pybmc uses the GPLv3 license. |
+| 5. | Provide a runtime API to return the current version number of the software. |Full| The version can be returned within Python via: `pybmc.__version__`.|
+| 6. | Provide a BAND team-accessible repository. |Full| https://github.com/ascsn/pybmc |
+| 7. | Must allow installing, building, and linking against an outside copy of all imported software that is externally developed and maintained |Full| pybmc does not contain any other package's source code. Note that Python packages are imported using the conventional `sys.path` system. Alternative instances of a package can be used, for example, by including them through an appropriate definition of the `PYTHONPATH` environment variable.|
+| 8. | Have no hardwired print or IO statements that cannot be turned off |Full| In pybmc, errors are handled through Python's exception handling. |
+
+### Recommended Policies
+
+| # | Policy                 |Support| Notes                   |
+|---|------------------------|-------|-------------------------|
+|**R1.**| Have a public repository. |Full| https://github.com/ascsn/pybmc is publicly available. |
+|**R2.**| Free all system resources acquired as soon as they are no longer needed. |Full| Python has built-in garbage collection that frees memory when it becomes unreferenced. |
+|**R3.**| Provide a mechanism to export ordered list of library dependencies. |Full| The dependencies for pybmc are given in `pyproject.toml`. `pip install pybmc` installs required dependencies if they do not already exist. |
+|**R4.**| Document versions of packages that it works with or depends upon, preferably in machine-readable form.  |Full| A full list of tested external dependencies is provided in `pyproject.toml`. |
+|**R5.**| Have SUPPORT, LICENSE, and CHANGELOG files in top directory.  |Partial| All files are included in the main branch of the repository. |
+|**R6.**| Have sufficient documentation to support use and further development. |Full| pybmc provides documentation through the mkdocs framework. It is published on [GitHub Pages](https://ascsn.github.io/pybmc/), which includes a user guide covering quick-start, installation, and many usage details. The API page contains information on internal modules. |
+|**R7.**| Be buildable using 64-bit pointers; 32-bit is optional |Full| There is no explicit use of pointers in pybmc since Python handles pointers internally and depends on the install of Python, which will generally be 64-bit on supported systems.|
+|**R8.**| Do not assume a full MPI communicator; allow for user-provided MPI communicator |Full| pybmc does not use MPI. |
+|**R9.**| Use a limited and well-defined name space (e.g., symbol, macro, library, include) |Full| pybmc modules are located in the `pybmc` directory.|
+|**R10.**| Give best effort at portability to key architectures |Full| pybmc is being regularly tested via github actions CI/CD workflows.  |
+|**R11.**| Install headers and libraries under `<prefix>/include` and `<prefix>/lib`, respectively |Full| The standard Python installation is used for Python dependencies. This installs external Python packages under `<install-prefix>/lib/python<X.Y>/site-packages/`.|
+|**R12.**| All BAND compatibility changes should be sustainable |Full| The BAND-SDK-compatible package is in the standard release path. All the changes here should be sustainable.|
+|**R13.**| Respect system resources and settings made by other previously called packages |Full| pybmc does not modify system resources or settings.|
+|**R14.**| Provide a comprehensive test suite for correctness of installation verification. |Full| pybmc contains a comprehensive set of unit tests that can be run, individually or all at once, via pytest with a high coverage.|


### PR DESCRIPTION
This pull request adds documentation for the integration of the `pybmc` Python package into the BAND Framework, including a BAND SDK compatibility statement and a usage README. It also updates the `AUTHORS` file to recognize new contributors.

**Documentation for pybmc integration:**

* Added a new `README.md` in `software/pybmc` describing the purpose of `pybmc`, installation instructions, usage examples, and links to further documentation.
* Introduced a `pybmc-bandsdk.md` file documenting the compatibility of `pybmc` with the BAND SDK v0.2 Community Policy, detailing compliance with both mandatory and recommended policies, and providing contact and repository information.

**Project metadata updates:**

* Updated the `AUTHORS` file to add Troy Dasher and An Le as contributors.