### PR TITLE
include surmise v0.4 in update

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -39,6 +39,7 @@ JIT
 jitrbandsdk
 JOSS
 Jupyter
+Jupyterbook
 Kataria
 lcgp
 LHS

--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -39,7 +39,6 @@ JIT
 jitrbandsdk
 JOSS
 Jupyter
-Jupyterbook
 Kataria
 lcgp
 LHS

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,8 @@ New capabilities and notable changes:
 - Updated BAND-compatible jitr to `v2.5.1 <https://github.com/beykyle/jitr/releases/tag/v2.5.1>`_, which fixes bugs in calculating some observables; also adds mass tables, a Reaction class, many examples, and other functionality. 
 - Updated BAND-compatible rose to `v1.1.7 <https://github.com/bandframework/rose/releases/tag/v1.1.7>`_, which includes minor bug fixes.
 - Updated BAND-compatible SAMBA to `v1.2.0 <https://github.com/asemposki/SAMBA/releases/tag/v1.2.0>`_, which fixes some GP mixing bugs. 
-- Updated BAND-compatible PUQ to `v0.1.1 <https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1>`_, which extends hetGPy as a base surrogate module and includes two novel sequential design strategies for stochastic simulation models. 
+- updated BAND-compatible surmise to `v0.4.0 <https://github.com/bandframework/surmise/releases/tag/v0.4.0>`_, which improves coverage of test suite, integrates Jupyterbook usage examples, and reassigns research (not fully-tested) code.
+- Updated BAND-compatible PUQ to `v0.1.1 <https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1>`_, which extends hetGPy as a base surrogate module and includes two novel sequential design strategies for stochastic simulation models.
 
 Release 0.4.0
 -------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ New capabilities and notable changes:
 - Updated BAND-compatible jitr to `v2.5.1 <https://github.com/beykyle/jitr/releases/tag/v2.5.1>`_, which fixes bugs in calculating some observables; also adds mass tables, a Reaction class, many examples, and other functionality. 
 - Updated BAND-compatible rose to `v1.1.7 <https://github.com/bandframework/rose/releases/tag/v1.1.7>`_, which includes minor bug fixes.
 - Updated BAND-compatible SAMBA to `v1.2.0 <https://github.com/asemposki/SAMBA/releases/tag/v1.2.0>`_, which fixes some GP mixing bugs. 
-- updated BAND-compatible surmise to `v0.4.0 <https://github.com/bandframework/surmise/releases/tag/v0.4.0>`_, which improves coverage of test suite, integrates Jupyterbook usage examples, and reassigns research (not fully-tested) code.
+- updated BAND-compatible surmise to `v0.4.0 <https://github.com/bandframework/surmise/releases/tag/v0.4.0>`_, which improves coverage of test suite, integrates Jupyter Book usage examples, and reassigns research (not fully-tested) code.
 - Updated BAND-compatible PUQ to `v0.1.1 <https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1>`_, which extends hetGPy as a base surrogate module and includes two novel sequential design strategies for stochastic simulation models.
 
 Release 0.4.0

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ BAND Framework elements are of three main types:
 The BAND Framework's software tools can be found in [software/](/software/). 
 As of version 0.4.0+dev, the following tools are included:
 
-- surmise ([v0.3.0](https://github.com/bandframework/surmise/releases/tag/v0.3.0 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
+- surmise ([v0.4.0](https://github.com/bandframework/surmise/releases/tag/v0.4.0 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
 - [SmoothEmulator](/software/SmoothEmulator): A simplex sampler, emulator trainer, and MCMC explorer that employs a smooth emulator.
 - parMOO ([v0.4.1](https://github.com/parmoo/parmoo/releases/tag/v0.4.1 )): A Python library for parallel multiobjective simulation optimization.
 - rose ([v1.1.7](https://github.com/bandframework/rose/releases/tag/v1.1.7 )): A reduced-order scattering emulator.

--- a/software/README.md
+++ b/software/README.md
@@ -6,7 +6,7 @@ this directory.**
 
 As of v0.4.0+dev the following packages are present in this directory. 
 
-- surmise ([v0.3.0](https://github.com/bandframework/surmise/releases/tag/v0.3.0 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
+- surmise ([v0.4.0](https://github.com/bandframework/surmise/releases/tag/v0.4.0 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
 - [SmoothEmulator](/software/SmoothEmulator): A simplex sampler, emulator trainer, and MCMC explorer that employs a smooth emulator.
 - parMOO ([v0.4.1](https://github.com/parmoo/parmoo/releases/tag/v0.4.1 )): A Python library for parallel multiobjective simulation optimization.
 - rose ([v1.1.7](https://github.com/bandframework/rose/releases/tag/v1.1.7 )): A reduced-order scattering emulator.


### PR DESCRIPTION
For BAND reviewers, first of all, thanks for spending the time to review and test.  Below is a review checklist:

- [ ] **Copy the following in a new comment for your review**.

*Functionality tests*
- [ ] Follow instruction under [Installation](https://surmise.readthedocs.io/en/latest/introduction.html#installation) to install surmise.  If you have an existing surmise installation, you may want to upgrade surmise with `pip install surmise --upgrade`.
- [ ] ```import surmise; print(surmise.__version__)``` should return `0.4.0`.
- [ ] To test `surmise`, run `surmise.test()` within a Python environment, according to [Testing](https://surmise.readthedocs.io/en/latest/introduction.html#testing).
  - Warnings of invalid `sqrt` in `PTLMC` are currently expected and referenced in [surmise#182](https://github.com/bandframework/surmise/issues/182#issue-3504503222)
- [ ] Run `GP_surmise` [public colab jupyter notebook](https://colab.research.google.com/drive/1f4gKTCLEAGE8r-aMWOoGvY-O6zNqg1qj?usp=drive_link).  "Run all" should return the appropriate outputs and graphs without error.

*Documentation review*
- [ ] Review BAND SDK.