### PR TITLE
Update BMEX BAND Example

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ New capabilities and notable changes:
 - Updated BAND-compatible SAMBA to `v1.2.0 <https://github.com/asemposki/SAMBA/releases/tag/v1.2.0>`_, which fixes some GP mixing bugs. 
 - updated BAND-compatible surmise to `v0.4.0 <https://github.com/bandframework/surmise/releases/tag/v0.4.0>`_, which improves coverage of test suite, integrates Jupyter Book usage examples, and reassigns research (not fully-tested) code.
 - Updated BAND-compatible PUQ to `v0.1.1 <https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1>`_, which extends hetGPy as a base surrogate module and includes two novel sequential design strategies for stochastic simulation models.
+- Updated BAND example BMEX to `v0.1.4 <https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.4>`_, which includes minor quality of life improvements and bug fixes.
 
 Release 0.4.0
 -------------

--- a/examples/BMEX/BMEX-bandsdk.md
+++ b/examples/BMEX/BMEX-bandsdk.md
@@ -16,7 +16,7 @@
 **Website:** https://bmex.dev \
 **Contact:** kyle@bmex.dev \
 **Icon:** https://raw.githubusercontent.com/massexplorer/bmex-static/main/public/bmex-ico.png \
-**Description:** The Bayesian Mass Explorer (BMEX) is a user-focused web application that provides a one-stop-shop for quantified theoretical model predictions of nuclear masses and related quantities.
+**Description:** The Bayesian Mass Explorer (BMEX) is a user-focused web application that provides a one-stop-shop for quantified theoretical model predictions of nuclear masses and related quantities. The version adopted for the BAND release is [V0.1.4](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.4)
 
 
 ### Mandatory Policies

--- a/examples/BMEX/BMEX-bandsdk.md
+++ b/examples/BMEX/BMEX-bandsdk.md
@@ -16,7 +16,7 @@
 **Website:** https://bmex.dev \
 **Contact:** kyle@bmex.dev \
 **Icon:** https://raw.githubusercontent.com/massexplorer/bmex-static/main/public/bmex-ico.png \
-**Description:** The Bayesian Mass Explorer (BMEX) is a user-focused web application that provides a one-stop-shop for quantified theoretical model predictions of nuclear masses and related quantities. The version adopted for the BAND release is [v0.1.4](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.4)
+**Description:** The Bayesian Mass Explorer (BMEX) is a user-focused web application that provides a one-stop-shop for quantified theoretical model predictions of nuclear masses and related quantities. The version adopted for the BAND release is [v0.1.4](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.4).
 
 
 ### Mandatory Policies

--- a/examples/BMEX/BMEX-bandsdk.md
+++ b/examples/BMEX/BMEX-bandsdk.md
@@ -16,7 +16,7 @@
 **Website:** https://bmex.dev \
 **Contact:** kyle@bmex.dev \
 **Icon:** https://raw.githubusercontent.com/massexplorer/bmex-static/main/public/bmex-ico.png \
-**Description:** The Bayesian Mass Explorer (BMEX) is a user-focused web application that provides a one-stop-shop for quantified theoretical model predictions of nuclear masses and related quantities. The version adopted for the BAND release is [V0.1.4](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.4)
+**Description:** The Bayesian Mass Explorer (BMEX) is a user-focused web application that provides a one-stop-shop for quantified theoretical model predictions of nuclear masses and related quantities. The version adopted for the BAND release is [v0.1.4](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.4)
 
 
 ### Mandatory Policies

--- a/examples/BMEX/README.md
+++ b/examples/BMEX/README.md
@@ -4,7 +4,7 @@
 
 The Bayesian Mass Explorer (BMEX) is a user-focused web application that provides a one-stop-shop for quantified theoretical model predictions of nuclear masses and related quantities.
 
-A [BAND SDK v0.2 Community Policy](/resources/sdkpolicies/bandsdk.md) compatibility documentation for BMEX is contained in [BMEX-bandsdk.md](/software/BMEX/BMEX-bandsdk.imd).
+A [BAND SDK v0.2 Community Policy](/resources/sdkpolicies/bandsdk.md) compatibility documentation for BMEX is contained in [BMEX-bandsdk.md](/examples/BMEX/BMEX-bandsdk.md). The version adopted for the BAND framework is [v0.1.4](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.4)
 
 
 ## Accessing BMEX

--- a/examples/BMEX/README.md
+++ b/examples/BMEX/README.md
@@ -4,7 +4,7 @@
 
 The Bayesian Mass Explorer (BMEX) is a user-focused web application that provides a one-stop-shop for quantified theoretical model predictions of nuclear masses and related quantities.
 
-A [BAND SDK v0.2 Community Policy](/resources/sdkpolicies/bandsdk.md) compatibility documentation for BMEX is contained in [BMEX-bandsdk.md](/examples/BMEX/BMEX-bandsdk.md). The version adopted for the BAND framework is [v0.1.4](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.4)
+A [BAND SDK v0.2 Community Policy](/resources/sdkpolicies/bandsdk.md) compatibility documentation for BMEX is contained in [BMEX-bandsdk.md](/examples/BMEX/BMEX-bandsdk.md). The version adopted for the BAND framework is [v0.1.4](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.4).
 
 
 ## Accessing BMEX

--- a/examples/BMEX/README.md
+++ b/examples/BMEX/README.md
@@ -15,11 +15,10 @@ From the landing page, links to the various sub-applications can be found, with 
 One can cite the software with the following bibtex entry:
 ```
 @software{bmex,
-  author       = {Kyle Godbey, Landon Buskirk, and
-                  Pablo Giuliani},
+  author       = {Kyle Godbey and Landon Buskirk and Troy Dasher and Pablo Giuliani},
   title        = {{BMEX} - {T}he {B}ayesian {M}ass {E}xplorer},
-  month        = sep,
-  year         = 2023,
+  month        = jul,
+  year         = 2025,
   publisher    = {Zenodo},
   doi          = {10.5281/zenodo.7111988},
   url          = {https://doi.org/10.5281/zenodo.7111988}


### PR DESCRIPTION
This pull request updates documentation and metadata for the BMEX example to reflect the adoption of version v0.1.4 in the BAND framework. It also updates the BMEX citation information.

**BMEX version and documentation updates:**

* Updated the BMEX example in the `CHANGELOG.rst` to indicate the adoption of version v0.1.4, which includes minor quality of life improvements and bug fixes.
* Updated the `examples/BMEX/BMEX-bandsdk.md` and `examples/BMEX/README.md` files to specify that the BAND release uses BMEX v0.1.4, and corrected the location of the SDK policy documentation link. [[1]](diffhunk://#diff-9be5dd24566c990a137102a869cfb64d26f18d75542b8fb259a3f471e1d1ef22L19-R19) [[2]](diffhunk://#diff-4a4e81adf29d2b70ce5b441a1375cd01d336e646a504532c0205c7c007936ecbL7-R7)

**Citation and metadata corrections:**

* Updated the BMEX citation in `examples/BMEX/README.md` to include Troy Dasher as an author.