### PR TITLE
Adding submodule ModelDiscrepancy to examples folder

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -46,6 +46,7 @@ LLNL
 Loeppky
 MCMC
 MERCHANTABILITY
+ModelDiscrepancy
 MPI
 MPIExecutor
 NN

--- a/.github/workflows/bandframework-ci.yml
+++ b/.github/workflows/bandframework-ci.yml
@@ -30,5 +30,5 @@ jobs:
       - name: URL Checker
         uses: paramt/url-checker@master
         with:
-          files: "README.md,software/README.md,resources/README.md,resources/sdkpolicies/README.md,resources/sdkpolicies/bandsdk.md,resources/sdkpolicies/template.md,resources/dev_guide/git_instructions_for_submodules.md"
-          blacklist: https://doi.org/10.1088/1361-6471/abf1df,BMEX-bandsdk.md,Taweretbandsdk.md,SAMBAbandsdk.md,brickbandsdk.md,surmisebandsdk.md,frescoxbandsdk.md,template.md,bandsdk.md,parmoo-bandsdk.md,foobandsdk.md,PUQ-bandsdk.md,nsat-bandsdk.md,SmoothEmulatorSDK.md,jitrbandsdk.md,lcgp-bandsdk.md,pybmc-bandsdk.md
+          files: "README.md,software/README.md,resources/README.md,resources/sdkpolicies/README.md,resources/sdkpolicies/bandsdk.md,resources/sdkpolicies/template.md,resources/dev_guide/git_instructions_for_submodules.md,examples/README.md,BANDsoftware_uses/README.md"
+          blacklist: https://doi.org/10.1088/1361-6471/abf1df,BMEX-bandsdk.md,Taweretbandsdk.md,SAMBAbandsdk.md,brickbandsdk.md,surmisebandsdk.md,frescoxbandsdk.md,template.md,bandsdk.md,parmoo-bandsdk.md,foobandsdk.md,PUQ-bandsdk.md,nsat-bandsdk.md,SmoothEmulatorSDK.md,jitrbandsdk.md,lcgp-bandsdk.md,pybmc-bandsdk.md,MD-bandsdk.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "examples/neutron-rich-bmm"]
 	path = examples/neutron-rich-bmm
 	url = https://github.com/asemposki/neutron-rich-bmm
+[submodule "examples/ModelDiscrepancy"]
+	path = examples/ModelDiscrepancy
+	url = https://github.com/sjaiswal-tifr/ModelDiscrepancy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ New organization:
 New capabilities and notable changes:
 
 - Added BAND-compatible lcgp at `v0.2.1 <https://github.com/mosesyhc/LCGP/releases/tag/v0.2.1>`_, a tool for latent component Gaussian process emulation for multivariate stochastic simulations.
+- Added BAND-compatible ModelDiscrepancy at `v1.1.0 <https://github.com/sjaiswal-tifr/ModelDiscrepancy/tree/32d7d2c46009bc8c67a86580a088fb1b747ae029>`_, an example Bayesian framework for model-data comparison that accounts for theoretical uncertainties.
 - Added BAND-compatible neutron-rich-bmm at `v0.1.0 <https://github.com/asemposki/neutron-rich-bmm/releases/tag/v0.1.0>`_, an example of Gaussian process Bayesian model mixing for the dense matter equation of state.
 - Added BAND-compatible pybmc at `v0.2.4 <https://github.com/ascsn/pybmc/releases/tag/v0.2.4>`_, a tool for performing Bayesian model combination on various predictive models.
 - Updated BAND-compatible jitr to `v2.5.1 <https://github.com/beykyle/jitr/releases/tag/v2.5.1>`_, which fixes bugs in calculating some observables; also adds mass tables, a Reaction class, many examples, and other functionality. 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ As of version 0.4.0+dev, the following tools are included:
 The following [examples](/examples/) are included in version 0.4.0+dev:
 - BMEX ([v0.1.1](https://github.com/massexplorer/bmex-masses/releases/tag/v0.1.1 )): A web application for exploring quantified theoretical model predictions of nuclear masses and related quantities.
 - [BRICK](/examples/BRICK): The Bayesian R-matrix Inference Code Kit, designed to facilitate extraction of R-matrix parameters from experimental data.
+- ModelDiscrepancy ([v1.1.0](https://github.com/sjaiswal-tifr/ModelDiscrepancy/tree/32d7d2c46009bc8c67a86580a088fb1b747ae029 )): A Bayesian framework for model-data comparison that accounts for theoretical uncertainties.
 - neutron-rich-bmm ([v0.1.0](https://github.com/asemposki/neutron-rich-bmm/releases/tag/v0.1.0 )): An example of Gaussian process Bayesian model mixing for the dense matter equation of state.
 - [nsat](https://github.com/cdrischler/nuclear_saturation/tree/c4cfa45a1180b2739e217102d7380736d6844a11): A Bayesian mixture model approach to quantifying the empirical nuclear saturation point.
 - [QGP_Bayes](https://github.com/danOSU/QGP_Bayes/tree/4b3e2364f87a29ad2469f2b072053420fdaac8e9): A tutorial on the use of JETSCAPE_SIMS tools to infer parameters of the QGP.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ As of 0.4.0+dev this directory includes the following examples:
 
 - [BMEX](BMEX/): A web application for exploring quantified theoretical model predictions of nuclear masses and related quantities.
 - [BRICK](BRICK/): The Bayesian R-matrix Inference Code Kit, designed to facilitate extraction of R-matrix parameters from experimental data.
+- ModelDiscrepancy ([v1.1.0](https://github.com/sjaiswal-tifr/ModelDiscrepancy/tree/32d7d2c46009bc8c67a86580a088fb1b747ae029 )): A Bayesian framework for model-data comparison that accounts for theoretical uncertainties.
 - [neutron-rich-bmm](https://github.com/asemposki/neutron-rich-bmm/tree/07054335346e4a26ed919967e818cccd2d52c7ef): A Gaussian process Bayesian model mixing approach for microscopic constraints for the equation of state and structure of neutron stars.
 - [nsat](https://github.com/cdrischler/nuclear_saturation/tree/06cf466c2ab5f6e1fccafc18807c7dd99aff05c7): A Bayesian mixture model approach to quantifying the empirical nuclear saturation point.
 - [QGP_Bayes](https://github.com/danOSU/QGP_Bayes/tree/4b3e2364f87a29ad2469f2b072053420fdaac8e9): A tutorial on the use of JETSCAPE_SIMS tools to infer parameters of the QGP.

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,5 +9,5 @@ As of 0.4.0+dev this directory includes the following examples:
 - [neutron-rich-bmm](https://github.com/asemposki/neutron-rich-bmm/tree/07054335346e4a26ed919967e818cccd2d52c7ef): A Gaussian process Bayesian model mixing approach for microscopic constraints for the equation of state and structure of neutron stars.
 - [nsat](https://github.com/cdrischler/nuclear_saturation/tree/06cf466c2ab5f6e1fccafc18807c7dd99aff05c7): A Bayesian mixture model approach to quantifying the empirical nuclear saturation point.
 - [QGP_Bayes](https://github.com/danOSU/QGP_Bayes/tree/4b3e2364f87a29ad2469f2b072053420fdaac8e9): A tutorial on the use of JETSCAPE_SIMS tools to infer parameters of the QGP.
-- SaMBA ([v1.2.0](https://github.com/asemposki/SAMBA/tree/3f255109624be5fa5e761f4acfad35b9d61a00d1)): The Sandbox for Mixing via Bayesian Analysis.
+- SaMBA ([v1.2.0](https://github.com/asemposki/SAMBA/tree/3f255109624be5fa5e761f4acfad35b9d61a00d1 )): The Sandbox for Mixing via Bayesian Analysis.
 

--- a/resources/sdkpolicies/README.md
+++ b/resources/sdkpolicies/README.md
@@ -14,6 +14,7 @@ Examples of completed SDK policy compatibility documents include:
 -  [frescoxbandsdk.md](/software/Bfrescox/frescoxbandsdk.md)
 -  [jitrbandsdk.md](https://github.com/beykyle/jitr/blob/main/jitrbandsdk.md)
 -  [lcgp-bandsdk.md](https://github.com/mosesyhc/LCGP/blob/main/lcgp-bandsdk.md)
+-  [MD-bandsdk.md](https://github.com/sjaiswal-tifr/ModelDiscrepancy/blob/main/MD-bandsdk.md)
 -  [neutron-rich-bmm_bandsdk.md](https://github.com/asemposki/neutron-rich-bmm/blob/main/neutron-rich-bmm_bandsdk.md)
 -  [nsat-bandsdk.md](https://github.com/cdrischler/nuclear_saturation/blob/main/nsat-bandsdk.md)
 -  [parmoo-bandsdk.md](/software/parmoo/parmoo-bandsdk.md)


### PR DESCRIPTION
PR to add the submodule to `examples/ModelDiscrepancy`.