### PR TITLE
Fixing links of SAMBA package to reflect newest v1.2.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ New capabilities and notable changes:
 - Added BAND-compatible Bfrescox at `v0.0.1-alpha <https://github.com/bandframework/Bfrescox/releases/tag/v0.0.1-alpha>`_, A Python wrapper for the Frescox coupled reaction channel code.
 - Updated BAND-compatible jitr to `v2.5.1 <https://github.com/beykyle/jitr/releases/tag/v2.5.1>`_, which fixes bugs in calculating some observables; also adds mass tables, a Reaction class, many examples, and other functionality. 
 - Updated BAND-compatible rose to `v1.1.7 <https://github.com/bandframework/rose/releases/tag/v1.1.7>`_, which includes minor bug fixes.
-- Updated BAND-compatible SAMBA to `v1.2.0 <https://github.com/asemposki/SAMBA/releases/tag/v1.2.0>`_, which fixes some GP mixing bugs. 
+- Updated BAND-compatible SAMBA to `v1.2.1 <https://github.com/asemposki/SAMBA/releases/tag/v1.2.1>`_, which fixes some GP mixing bugs in v1.2.0 and updates documentation in v1.2.1. 
 - updated BAND-compatible surmise to `v0.4.0 <https://github.com/bandframework/surmise/releases/tag/v0.4.0>`_, which improves coverage of test suite, integrates Jupyter Book usage examples, and reassigns research (not fully-tested) code.
 - updated BAND-compatible Taweret to `v1.2.0 <https://github.com/bandframework/Taweret/releases/tag/v1.2.0>`_, which updates the infrastructure and notebooks, and improves the documentation.
 - Updated BAND-compatible PUQ to `v0.1.1 <https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1>`_, which extends hetGPy as a base surrogate module and includes two novel sequential design strategies for stochastic simulation models.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following [examples](/examples/) are included in version 0.4.0+dev:
 - neutron-rich-bmm ([v0.1.0](https://github.com/asemposki/neutron-rich-bmm/releases/tag/v0.1.0 )): An example of Gaussian process Bayesian model mixing for the dense matter equation of state.
 - [nsat](https://github.com/cdrischler/nuclear_saturation/tree/c4cfa45a1180b2739e217102d7380736d6844a11): A Bayesian mixture model approach to quantifying the empirical nuclear saturation point.
 - [QGP_Bayes](https://github.com/danOSU/QGP_Bayes/tree/4b3e2364f87a29ad2469f2b072053420fdaac8e9): A tutorial on the use of JETSCAPE_SIMS tools to infer parameters of the QGP.
-- SaMBA ([v1.2.0](https://github.com/asemposki/SAMBA/tree/3f255109624be5fa5e761f4acfad35b9d61a00d1 )): The Sandbox for Mixing via Bayesian Analysis.
+- SAMBA ([v1.2.1](https://github.com/asemposki/SAMBA/releases/tag/v1.2.1 )): The Sandbox for Mixing via Bayesian Analysis.
 
 
 ## Downloading and using the BAND Framework

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,5 +9,5 @@ As of 0.4.0+dev this directory includes the following examples:
 - [neutron-rich-bmm](https://github.com/asemposki/neutron-rich-bmm/tree/07054335346e4a26ed919967e818cccd2d52c7ef): A Gaussian process Bayesian model mixing approach for microscopic constraints for the equation of state and structure of neutron stars.
 - [nsat](https://github.com/cdrischler/nuclear_saturation/tree/06cf466c2ab5f6e1fccafc18807c7dd99aff05c7): A Bayesian mixture model approach to quantifying the empirical nuclear saturation point.
 - [QGP_Bayes](https://github.com/danOSU/QGP_Bayes/tree/4b3e2364f87a29ad2469f2b072053420fdaac8e9): A tutorial on the use of JETSCAPE_SIMS tools to infer parameters of the QGP.
-- SaMBA ([v1.2.0](https://github.com/asemposki/SAMBA/tree/3f255109624be5fa5e761f4acfad35b9d61a00d1 )): The Sandbox for Mixing via Bayesian Analysis.
+- SaMBA ([v1.2.1](https://github.com/asemposki/SAMBA/tree/9fa6c55d7966457e271b3e2a660eba4bcc1dcd6b )): The Sandbox for Mixing via Bayesian Analysis.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,5 +9,5 @@ As of 0.4.0+dev this directory includes the following examples:
 - [neutron-rich-bmm](https://github.com/asemposki/neutron-rich-bmm/tree/07054335346e4a26ed919967e818cccd2d52c7ef): A Gaussian process Bayesian model mixing approach for microscopic constraints for the equation of state and structure of neutron stars.
 - [nsat](https://github.com/cdrischler/nuclear_saturation/tree/06cf466c2ab5f6e1fccafc18807c7dd99aff05c7): A Bayesian mixture model approach to quantifying the empirical nuclear saturation point.
 - [QGP_Bayes](https://github.com/danOSU/QGP_Bayes/tree/4b3e2364f87a29ad2469f2b072053420fdaac8e9): A tutorial on the use of JETSCAPE_SIMS tools to infer parameters of the QGP.
-- SaMBA ([v1.2.1](https://github.com/asemposki/SAMBA/tree/9fa6c55d7966457e271b3e2a660eba4bcc1dcd6b )): The Sandbox for Mixing via Bayesian Analysis.
+- SAMBA ([v1.2.1](https://github.com/asemposki/SAMBA/tree/9fa6c55d7966457e271b3e2a660eba4bcc1dcd6b )): The Sandbox for Mixing via Bayesian Analysis.
 


### PR DESCRIPTION
In the README, examples README, and CHANGELOG files, I have replaced the SAMBA URLs with the newest tagged release notes URL and the commit URL where needed. Everything should now point to the proper release and commit.