### PR TITLE
Improve release procedure

### DIFF
--- a/resources/dev_guide/release-proc.rst
+++ b/resources/dev_guide/release-proc.rst
@@ -64,5 +64,8 @@ After release
 - Ensure all relevant GitHub issues are closed.
 
 - Update website to reflect existence of new release.
+  
+  - Update if necessary the BAND framework tools list in the `software page <https://bandframework.github.io/software>`_ as well all tool descriptions in that page to match contents of new release.
+  - Confirm that links to different BAND framework tools in the `software page <https://bandframework.github.io/software>`_ function and go to the correct target.
 
 - Disseminate news of new release to: FRIB-TA mailing list, JETSCAPE/X-SCAPE mailing list, other interested parties.

--- a/resources/dev_guide/release-proc.rst
+++ b/resources/dev_guide/release-proc.rst
@@ -65,7 +65,7 @@ After release
 
 - Update website to reflect existence of new release.
   
-  - Update if necessary the BAND framework tools list in the `software page <https://bandframework.github.io/software>`_ as well all tool descriptions in that page to match contents of new release.
+  - Update if necessary the BAND framework tools list in the `software page <https://bandframework.github.io/software>`_ as well as all tool descriptions in that page to match contents of new release.
   - Confirm that links to different BAND framework tools in the `software page <https://bandframework.github.io/software>`_ function and go to the correct target.
 
 - Disseminate news of new release to: FRIB-TA mailing list, JETSCAPE/X-SCAPE mailing list, other interested parties.


### PR DESCRIPTION
This addresses Issue #197 and is a redo of PR #198 as requested by reviewers of that PR.  In particular, these changes are based off of `develop` for merging into `develop`.

The changes here already address (hopefully) other change requests from that PR.

- [x] Review changes
- [x] Confirm correct rendering of new content as seen through GH web interface
- [x] Confirm all actions passing