### PR TITLE
Update README.md for pybmc version change to v0.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ Below are the release notes for all bandframework releases.
 May reference issues on:
 https://github.com/bandframework/bandframework/issues
 
+https://band.kyle.ee/
+
+Release 1.0.0
+-------------
+:Date: XXXXXX
+
+New capabilities and notable changes:
+
+- updated BAND-compatible pybmc at `v0.3.0 <https://github.com/ascsn/pybmc/releases/tag/v0.3.0>`_, a tool for performing Bayesian model combination on various predictive models.
+
+
+
 Release 0.5.0
 -------------
 :Date: December 22, 2025

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,15 +6,14 @@ Below are the release notes for all bandframework releases.
 May reference issues on:
 https://github.com/bandframework/bandframework/issues
 
-https://band.kyle.ee/
 
 Release 1.0.0
 -------------
-:Date: XXXXXX
+:Date: TBD
 
 New capabilities and notable changes:
 
-- updated BAND-compatible pybmc at `v0.3.0 <https://github.com/ascsn/pybmc/releases/tag/v0.3.0>`_, a tool for performing Bayesian model combination on various predictive models.
+- updated BAND-compatible pybmc at `v0.4.1 <https://github.com/ascsn/pybmc/releases/tag/v0.4.1>`_, a tool for performing Bayesian model combination on various predictive models.
 
 
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ As of version 0.5.0+dev, the following tools are included:
 - LCGP ([v0.2.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
 - parMOO ([v0.4.1](https://github.com/parmoo/parmoo/releases/tag/v0.4.1 )): A Python library for parallel multiobjective simulation optimization.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
-- pybmc ([v0.2.4](https://github.com/ascsn/pybmc/releases/tag/v0.2.4 )): A Python package for performing Bayesian model combination on various predictive models.
+- pybmc ([v0.3.0](https://github.com/ascsn/pybmc/releases/tag/v0.3.0 )): A Python package for performing Bayesian model combination on various predictive models.
 - rose ([v1.1.7](https://github.com/bandframework/rose/releases/tag/v1.1.7 )): A reduced-order scattering emulator.
 - [SmoothEmulator](/software/SmoothEmulator): A simplex sampler, emulator trainer, and MCMC explorer that employs a smooth emulator.
 - surmise ([v0.4.0](https://github.com/bandframework/surmise/releases/tag/v0.4.0 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.

--- a/software/pybmc/README.md
+++ b/software/pybmc/README.md
@@ -4,7 +4,7 @@ pybmc is a Python package for performing Bayesian Model Combination (BMC) on var
 
 A [BAND SDK v0.2 Community Policy](/resources/sdkpolicies/bandsdk.md) compatibility documentation for pybmc is contained in [pybmc-bandsdk.md](/software/pybmc/pybmc-bandsdk.md).
 
-The version of pybmc adopted for the BAND Framework is v0.2.4, found [here](https://github.com/ascsn/pybmc/tree/v0.2.4).
+The version of pybmc adopted for the BAND Framework is v0.3.0, found [here](https://github.com/ascsn/pybmc/tree/v0.3.0).
 
 ## pybmc Installation
 
@@ -31,4 +31,4 @@ pip install -e .
 
 ## pybmc Examples
 
-For a simple example of the package in action, check the Usage section of the documentation [here](https://ascsn.github.io/pybmc/usage/#1-load-and-prepare-data). For an interactive notebook of the same procedure, you can load [this file](https://github.com/ascsn/pybmc/blob/v0.2.4/pybmc/test.ipynb) locally or in any Jupyter environment.
+For a simple example of the package in action, check the Usage section of the documentation [here](https://ascsn.github.io/pybmc/usage/#1-load-and-prepare-data). For an interactive notebook of the same procedure, you can load [this file](https://github.com/ascsn/pybmc/blob/v0.3.0/pybmc/test.ipynb) locally or in any Jupyter environment.

--- a/software/pybmc/README.md
+++ b/software/pybmc/README.md
@@ -4,7 +4,7 @@ pybmc is a Python package for performing Bayesian Model Combination (BMC) on var
 
 A [BAND SDK v0.2 Community Policy](/resources/sdkpolicies/bandsdk.md) compatibility documentation for pybmc is contained in [pybmc-bandsdk.md](/software/pybmc/pybmc-bandsdk.md).
 
-The version of pybmc adopted for the BAND Framework is v0.3.0, found [here](https://github.com/ascsn/pybmc/tree/v0.3.0).
+The version of pybmc adopted for the BAND Framework is v0.4.1, found [here](https://github.com/ascsn/pybmc/tree/v0.3.0).
 
 ## pybmc Installation
 


### PR DESCRIPTION
In anticipation of the V1.0 release  (#212), I've updated pybmc and bumped the version in the project README.