### PR TITLE
Updating LCGP to v1.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,7 @@ Authors of BAND Framework v0.5.0+dev, listed alphabetically
 Kyle Beyer
 Landon Buskirk
 Manuel Catacora Rios
-Moses Y-H. Chan
+Moses Y.-H. Chan
 Tyler H. Chang
 Troy Dasher
 Richard James DeBoer
@@ -10,6 +10,7 @@ Christian Drischler
 Richard J. Furnstahl
 Pablo Giuliani
 Kyle Godbey
+Edbert Handjaja
 Kevin Ingles
 Sunil Jaiswal
 An Le

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The BAND Framework's software tools can be found in [software/](/software/).
 As of version 0.5.0+dev, the following tools are included:
 - Bfrescox ([v0.0.1-alpha](https://github.com/bandframework/Bfrescox/releases/tag/v0.0.1-alpha )): A Python wrapper for the Frescox coupled reaction channel code.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
-- LCGP ([v0.2.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
+- LCGP ([v1.1.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
 - OpenBT ([v1.2.0](https://github.com/bandframework/OpenBT/releases/tag/v1.2.0)): C++, Python, and R packages implementing Bayesian tree models, including regression, model mixing, sensitivity analysis and multiobjective optimization.
 - parMOO ([v0.5.1](https://github.com/parmoo/parmoo/releases/tag/v0.5.1 )): A Python library for parallel multiobjective simulation optimization.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The BAND Framework's software tools can be found in [software/](/software/).
 As of version 0.5.0+dev, the following tools are included:
 - Bfrescox ([v0.0.1-alpha](https://github.com/bandframework/Bfrescox/releases/tag/v0.0.1-alpha )): A Python wrapper for the Frescox coupled reaction channel code.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
-- LCGP ([v1.0.1](https://github.com/mosesyhc/lcgp/releases/tag/v1.0.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs, with and without replications.
+- LCGP ([v1.0.1](https://github.com/mosesyhc/lcgp/releases/tag/1.0.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs, with and without replications.
 - parMOO ([v0.4.1](https://github.com/parmoo/parmoo/releases/tag/v0.4.1 )): A Python library for parallel multiobjective simulation optimization.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - pybmc ([v0.2.4](https://github.com/ascsn/pybmc/releases/tag/v0.2.4 )): A Python package for performing Bayesian model combination on various predictive models.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The BAND Framework's software tools can be found in [software/](/software/).
 As of version 0.5.0+dev, the following tools are included:
 - Bfrescox ([v0.0.1-alpha](https://github.com/bandframework/Bfrescox/releases/tag/v0.0.1-alpha )): A Python wrapper for the Frescox coupled reaction channel code.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
-- LCGP ([v1.1.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
+- LCGP ([v1.1.1](https://github.com/mosesyhc/lcgp/releases/tag/1.1.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
 - OpenBT ([v1.2.0](https://github.com/bandframework/OpenBT/releases/tag/v1.2.0)): C++, Python, and R packages implementing Bayesian tree models, including regression, model mixing, sensitivity analysis and multiobjective optimization.
 - parMOO ([v0.5.1](https://github.com/parmoo/parmoo/releases/tag/v0.5.1 )): A Python library for parallel multiobjective simulation optimization.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The BAND Framework's software tools can be found in [software/](/software/).
 As of version 0.5.0+dev, the following tools are included:
 - Bfrescox ([v0.0.1-alpha](https://github.com/bandframework/Bfrescox/releases/tag/v0.0.1-alpha )): A Python wrapper for the Frescox coupled reaction channel code.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
-- LCGP ([v0.2.1](https://github.com/mosesyhc/lcgp/releases/tag/v0.2.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
+- LCGP ([v1.0.1](https://github.com/mosesyhc/lcgp/releases/tag/v1.0.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs, with and without replications.
 - parMOO ([v0.4.1](https://github.com/parmoo/parmoo/releases/tag/v0.4.1 )): A Python library for parallel multiobjective simulation optimization.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - pybmc ([v0.2.4](https://github.com/ascsn/pybmc/releases/tag/v0.2.4 )): A Python package for performing Bayesian model combination on various predictive models.
@@ -105,8 +105,8 @@ Please use the following to cite the BAND Framework:
     @techreport{bandframework,
         title       = {{BANDFramework: An} Open-Source Framework for {Bayesian} Analysis of Nuclear Dynamics},
         author      = {Kyle Beyer and Landon Buskirk and Manuel Catacora Rios and Moses Y-H. Chan and Tyler H. Chang and Troy Dasher 
-        and Richard James DeBoer and Christian Drischler and Richard J. Furnstahl and Pablo Giuliani and
-        Kyle Godbey and Kevin Ingles and Sunil Jaiswal and An Le and Dananjaya Liyanage and Filomena M. Nunes
+        and Richard James DeBoer and Christian Drischler and Richard J. Furnstahl and Pablo Giuliani and Kyle Godbey 
+        and Edbert Handjaja and Kevin Ingles and Sunil Jaiswal and An Le and Dananjaya Liyanage and Filomena M. Nunes
         and Daniel Odell and David O'Gara and Jared O'Neal and Daniel R. Phillips and Matthew Plumlee
         and Matthew T. Pratola and Scott Pratt and Oleh Savchuk and Alexandra C. Semposki and \"Ozge S\"urer and 
         Stefan M. Wild and John C. Yannotty},

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The BAND Framework's software tools can be found in [software/](/software/).
 As of version 0.5.0+dev, the following tools are included:
 - Bfrescox ([v0.0.1-alpha](https://github.com/bandframework/Bfrescox/releases/tag/v0.0.1-alpha )): A Python wrapper for the Frescox coupled reaction channel code.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
-- LCGP ([v1.0.1](https://github.com/mosesyhc/lcgp/releases/tag/1.0.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs, with and without replications.
+- LCGP ([v1.1.1](https://github.com/mosesyhc/lcgp/releases/tag/1.0.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs, with and without replications.
 - parMOO ([v0.4.1](https://github.com/parmoo/parmoo/releases/tag/v0.4.1 )): A Python library for parallel multiobjective simulation optimization.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - pybmc ([v0.2.4](https://github.com/ascsn/pybmc/releases/tag/v0.2.4 )): A Python package for performing Bayesian model combination on various predictive models.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Please use the following to cite the BAND Framework:
 
     @techreport{bandframework,
         title       = {{BANDFramework: An} Open-Source Framework for {Bayesian} Analysis of Nuclear Dynamics},
-        author      = {Kyle Beyer and Landon Buskirk and Manuel Catacora Rios and Moses Y-H. Chan and Tyler H. Chang and Troy Dasher 
+        author      = {Kyle Beyer and Landon Buskirk and Manuel Catacora Rios and Moses Y.-H. Chan and Tyler H. Chang and Troy Dasher 
         and Richard James DeBoer and Christian Drischler and Richard J. Furnstahl and Pablo Giuliani and Kyle Godbey 
         and Edbert Handjaja and Kevin Ingles and Sunil Jaiswal and An Le and Dananjaya Liyanage and Filomena M. Nunes
         and Daniel Odell and David O'Gara and Jared O'Neal and Daniel R. Phillips and Matthew Plumlee

--- a/software/README.md
+++ b/software/README.md
@@ -7,7 +7,7 @@ referenced therein, before attempting to contribute to this directory.**
 As of v0.5.0+dev the following packages are present in this directory:
 - Bfrescox (v0.0.1-alpha): A Python wrapper for the Frescox coupled reaction channel code.
 - jitr (v2.5.1): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
-- LCGP (v0.2.1): A Gaussian process surrogate model for emulating stochastic simulation outputs.
+- LCGP (v1.1.1): A Gaussian process surrogate model for emulating stochastic simulation outputs.
 - OpenBT (v1.2.0): C++, Python, and R packages implementing Bayesian tree models, including regression, model mixing, sensitivity analysis and multiobjective optimization.
 - parMOO (v0.5.1): A Python library for parallel multiobjective simulation optimization.
 - PUQ (v0.1.1): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.

--- a/software/README.md
+++ b/software/README.md
@@ -8,7 +8,7 @@ As of v0.5.0+dev the following packages are present in this directory.
 
 - Bfrescox (v0.0.1-alpha): A Python wrapper for the Frescox coupled reaction channel code.
 - jitr (v2.5.1): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
-- LCGP (v0.2.1): A Gaussian process surrogate model for emulating stochastic simulation outputs.
+- LCGP (v1.1.1): A Gaussian process surrogate model for emulating stochastic simulation outputs.
 - parMOO (v0.4.1): A Python library for parallel multiobjective simulation optimization.
 - PUQ (v0.1.1): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - pybmc (v0.2.4): A Python package for performing Bayesian model combination on various predictive models.


### PR DESCRIPTION
This PR refers to recent updated functionality in LCGP, see https://github.com/mosesyhc/LCGP/pull/20, as part of #212 

In summary, LCGP v1 
- includes stochastic emulator for data with or without replications.
- includes undergraduate student (Edbert Handjaja) as an author.
- updates README to include a set of experimental runs outside of the basic usage.

**Changes to BANDFramework documents**:

LCGP v1 introduces a new author (Edbert Handjaja) into the BAND framework:
- Bandframework AUTHOR and README are edited to reflect the addition.
- Bandframework README reflects new LCGP version.


Reviewers, you may test the LCGP package in the following manner:
1. Install LCGP according to [Installation](https://lcgp.readthedocs.io/en/latest/#installation)
2. Install additional packages for testing: `pip install matplotlib`
3. Test LCGP in the following ways:
   - By using the test suite included in LCGP, calling `import lcgp; lcgp.test()`.
   - By running the Python script `python illustration-examples/lcgp-rep-3d-illustration.py` and verifying the generated output figure.
   - By downloading and running the [Jupyter notebook](https://lcgp.readthedocs.io/en/latest/replications-illustration.html) in the documentation.  Download button is on the right top corner of the webpage.