### PR TITLE
mooGP inclusion to BAND

### DIFF
--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -181,6 +181,7 @@ md
 miamioh
 mlbayeswoodbury
 mkdocs
+moogp
 mooGP
 mosesyhc
 mplumlee

--- a/.github/config/.wordlist.txt
+++ b/.github/config/.wordlist.txt
@@ -171,6 +171,7 @@ md
 miamioh
 mlbayeswoodbury
 mkdocs
+mooGP
 mosesyhc
 mplumlee
 msu

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Authors of BAND Framework v0.5.0+dev, listed alphabetically
+Evan C. Barnett
 Kyle Beyer
 Landon Buskirk
 Manuel Catacora Rios

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ As of version 0.5.0+dev, the following tools are included:
 - Bfrescox ([v0.0.1-alpha](https://github.com/bandframework/Bfrescox/releases/tag/v0.0.1-alpha )): A Python wrapper for the Frescox coupled reaction channel code.
 - jitr ([v2.5.1](https://github.com/beykyle/jitr/releases/tag/v2.5.1 )): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
 - LCGP ([v1.1.1](https://github.com/mosesyhc/lcgp/releases/tag/1.1.1 )): A Gaussian process surrogate model for emulating stochastic simulation outputs.
+- mooGP ([v1.0.0](https://github.com/evancbarnett/mooGP/releases/tag/1.0.0)): Surrogate model for vector-valued (multi-output) functions with a multi-output orthogonal Gaussian process.
 - OpenBT ([v1.2.0](https://github.com/bandframework/OpenBT/releases/tag/v1.2.0)): C++, Python, and R packages implementing Bayesian tree models, including regression, model mixing, sensitivity analysis and multiobjective optimization.
 - parMOO ([v0.5.1](https://github.com/parmoo/parmoo/releases/tag/v0.5.1 )): A Python library for parallel multiobjective simulation optimization.
 - PUQ ([v0.1.1](https://github.com/parallelUQ/PUQ/releases/tag/v0.1.1 )): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Please use the following to cite the BAND Framework:
 
     @techreport{bandframework,
         title       = {{BANDFramework: An} Open-Source Framework for {Bayesian} Analysis of Nuclear Dynamics},
-        author      = {Kyle Beyer and Landon Buskirk and Manuel Catacora Rios and Moses Y-H. Chan and Tyler H. Chang and Troy Dasher 
+        author      = {Evan C. Barnett and Kyle Beyer and Landon Buskirk and Manuel Catacora Rios and Moses Y-H. Chan and Tyler H. Chang and Troy Dasher 
         and Richard James DeBoer and Christian Drischler and Richard J. Furnstahl and Pablo Giuliani and
         Kyle Godbey and Kevin Ingles and Sunil Jaiswal and An Le and Dananjaya Liyanage and Filomena M. Nunes
         and Daniel Odell and David O'Gara and Jared O'Neal and Daniel R. Phillips and Matthew Plumlee

--- a/resources/sdkpolicies/README.md
+++ b/resources/sdkpolicies/README.md
@@ -18,6 +18,7 @@ Examples of completed SDK policy compatibility documents include:
 -  [jitrbandsdk.md](https://github.com/beykyle/jitr/blob/main/jitrbandsdk.md)
 -  [lcgp-bandsdk.md](https://github.com/mosesyhc/LCGP/blob/main/lcgp-bandsdk.md)
 -  [MD-bandsdk.md](https://github.com/sjaiswal-tifr/ModelDiscrepancy/blob/main/MD-bandsdk.md)
+-  [moogp-sdk.md](https://github.com/evancbarnett/mooGP/blob/main/bandframework-moogp-sdk.md)
 -  [neutron-rich-bmm_bandsdk.md](https://github.com/asemposki/neutron-rich-bmm/blob/main/neutron-rich-bmm_bandsdk.md)
 -  [nsat-bandsdk.md](https://github.com/cdrischler/nuclear_saturation/blob/main/nsat-bandsdk.md)
 -  [OpenBTbandsdk.md](/software/OpenBT/OpenBTbandsdk.md)

--- a/software/README.md
+++ b/software/README.md
@@ -9,6 +9,7 @@ As of v0.5.0+dev the following packages are present in this directory.
 - Bfrescox (v0.0.1-alpha): A Python wrapper for the Frescox coupled reaction channel code.
 - jitr (v2.5.1): A Python package containing a Lagrange mesh R-matrix solver for parametric reaction model calibration.
 - LCGP (v0.2.1): A Gaussian process surrogate model for emulating stochastic simulation outputs.
+- mooGP (v1.0.0): Surrogate model for vector-valued (multi-output) functions with a multi-output orthogonal Gaussian process.
 - parMOO (v0.4.1): A Python library for parallel multiobjective simulation optimization.
 - PUQ (v0.1.1): A Python package for generating experimental designs tailored for uncertainty quantification and featuring parallel implementations.
 - pybmc (v0.2.4): A Python package for performing Bayesian model combination on various predictive models.


### PR DESCRIPTION
This is a new emulator package to be added to BAND, as part of #212 

Changes to BANDFramework files:
- Bandframework AUTHOR and README are edited to reflect the addition of author.
- Bandframework README reflects the inclusion of mooGP.

Reviewers, you may test the mooGP package in the following manner:

- Install mooGP according to [Installation](https://evancbarnett.github.io/mooGP/#installation)
- Test mooGP in the following ways:
  - By using the test suite included in mooGP, calling `import moogp; moogp.test()`.
  - By downloading and running the Jupyter notebooks in the [documentation](https://evancbarnett.github.io/mooGP). Download button is on the right top corner of each webpage.