### PR TITLE
Updating Taweret to v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ As of version 0.5.0+dev, the following tools are included:
 - pybmc ([v0.2.4](https://github.com/ascsn/pybmc/releases/tag/v0.2.4 )): A Python package for performing Bayesian model combination on various predictive models.
 - [SmoothEmulator](/software/SmoothEmulator): A simplex sampler, emulator trainer, and MCMC explorer that employs a smooth emulator.
 - surmise ([v0.4.0](https://github.com/bandframework/surmise/releases/tag/v0.4.0 )): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
-- Taweret ([v1.2.0](https://github.com/bandframework/Taweret/releases/tag/v1.2.0 )): A Python package containing multiple Bayesian Model Mixing methods.
+- Taweret ([v1.3.0](https://github.com/bandframework/Taweret/releases/tag/v1.3.0 )): A Python package containing multiple Bayesian Model Mixing methods.
 - rose ([v1.1.8](https://github.com/bandframework/rose/releases/tag/v1.1.8 )): A reduced-order scattering emulator. Note: no longer maintained, see [software/rose/README.md](https://github.com/bandframework/rose/blob/v1.1.8/README.md) for details.
 
 

--- a/software/README.md
+++ b/software/README.md
@@ -14,7 +14,7 @@ As of v0.5.0+dev the following packages are present in this directory:
 - pybmc (v0.2.4): A Python package for performing Bayesian model combination on various predictive models.
 - SmoothEmulator: A simplex sampler, emulator trainer, and MCMC explorer that employs a smooth emulator.
 - surmise (v0.4.0): A surrogate model interface for calibration, uncertainty quantification, and sensitivity analysis.
-- Taweret (v1.2.0): A Python package containing multiple Bayesian Model Mixing methods.
+- Taweret (v1.3.0): A Python package containing multiple Bayesian Model Mixing methods.
 - rose (v1.1.8): A reduced-order scattering emulator. Note: no longer maintained, see [rose/README.md](https://github.com/bandframework/rose/blob/v1.1.8/README.md) for details.
 
 Applications of these tools to nuclear-physics problems are provided in the ["BAND software uses"](/BANDsoftware_uses) directory. 


### PR DESCRIPTION
Taweret is ready for review to update the submodule in the BAND framework for v1.0. The v1.3.0 release of Taweret has been completed and the new source distributions for this release have been uploaded to PyPI [here](https://pypi.org/project/Taweret/).

There are two main ways to download Taweret: 1) via the PyPI link above; 2) using git clone on the GitHub repository site. Please test both ways if you are reviewing this PR. The readthedocs page [here](https://taweretdocs.readthedocs.io/en/latest/installation.html) has installation instructions for each operating system that will be of use.

1). PyPI download: go to the link above and download the package. Make sure that you can install it and run the tests in the folder Tests that is contained in the src/Taweret folder, including verifying the version of the package via Taweret.__version__() in a terminal running Python.

2). GitHub clone: clone the repository and follow the instructions in the README there to install and test the package.

We have our readthedocs page set up at [this page](https://taweretdocs.readthedocs.io/en/latest/index.html). Please verify that the version number of the package shows up at the top of the page under the Welcome header of docs main page and that the docs render correctly for you. We also have our Jupyter Book containing BMM tutorials located at [this link](https://bandframework.github.io/Taweret/landing.html). Please verify that the pages load correctly and that you can flip through the Book without any issues. To test the generation of the book, you can run tox -r -e book in the Taweret repository and all tests should pass there.

Some important notes: all tests should be passing when running the pytest files on the Taweret source code. You may encounter, when downloading and installing the package or running the tests, a deprecation warning for the bilby sampler involving setting parameters in the likelihood. We are aware of that warning. Please let us know if you run into any errors.